### PR TITLE
Fix Carousel Images

### DIFF
--- a/home.html
+++ b/home.html
@@ -134,7 +134,7 @@
         </div>
       </div>
       <div class="carousel-item slide2">
-        <svg class="bd-placeholder-img" width="100%" height="50%" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img"></svg>
+        <svg class="bd-placeholder-img" width="100%" height="50%" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img"><rect width="100%" height="100%" fill="#777"></rect></svg>
         <div class="container">
           <div class="carousel-caption">
             <h1>Davis A wins Sacramento Spring!</h1>
@@ -144,7 +144,7 @@
         </div>
       </div>
       <div class="carousel-item slide3">
-        <svg class="bd-placeholder-img" width="100%" height="50%" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img"></svg>
+        <svg class="bd-placeholder-img" width="100%" height="50%" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img"><rect width="100%" height="100%" fill="#777"></rect></svg>
         <div class="container">
           <div class="carousel-caption text-right">
             <h1>Davis Quiz Bowl soon to win Cal Cup!</h1>

--- a/home.html
+++ b/home.html
@@ -124,7 +124,7 @@
     </ol>
     <div class="carousel-inner">
       <div class="carousel-item slide1 active">
-        <div class="bd-placeholder-img" width="100%" height="50%"></div>
+        <svg class="bd-placeholder-img" width="100%" height="50%" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img"></svg>
         <div class="container test1">
           <div class="carousel-caption text-left">
             <h1>Davis coach wins CC Nationals</h1>
@@ -134,7 +134,7 @@
         </div>
       </div>
       <div class="carousel-item slide2">
-        <svg class="bd-placeholder-img" width="100%" height="50%" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img"><rect width="100%" height="100%" fill="#777"></rect></svg>
+        <svg class="bd-placeholder-img" width="100%" height="50%" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img"></svg>
         <div class="container">
           <div class="carousel-caption">
             <h1>Davis A wins Sacramento Spring!</h1>
@@ -144,7 +144,7 @@
         </div>
       </div>
       <div class="carousel-item slide3">
-        <svg class="bd-placeholder-img" width="100%" height="50%" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img"><rect width="100%" height="100%" fill="#777"></rect></svg>
+        <svg class="bd-placeholder-img" width="100%" height="50%" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img"></svg>
         <div class="container">
           <div class="carousel-caption text-right">
             <h1>Davis Quiz Bowl soon to win Cal Cup!</h1>


### PR DESCRIPTION
For some reason on Firefox, the setup for the first carousel slide wasn't appearing. This seems to fix it. Tested on Firefox and Chromium.